### PR TITLE
Fix: Resolve prerendering error for /account page

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,14 +1,15 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/globals.css';
 import Head from 'next/head';
+import { AuthProvider } from '../context/AuthContext';
 
 export default function App({ Component, pageProps }) {
   return (
-    <>
+    <AuthProvider>
       <Head>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" />
       </Head>
       <Component {...pageProps} />
-    </>
+    </AuthProvider>
   );
 }

--- a/src/pages/account.js
+++ b/src/pages/account.js
@@ -3,7 +3,7 @@ import { supabase } from '@/lib/supabaseClient';
 import { useAuth } from '../context/AuthContext';
 
 const AccountPage = () => {
-  const { user, isAdmin, session, setAuthError } = useAuth(); // Use session to re-check user if needed
+  const { user, isAdmin, session, setAuthError, loading: authLoading } = useAuth(); // Use session to re-check user if needed
 
   // Profile Form State
   const [profileData, setProfileData] = useState({
@@ -191,6 +191,19 @@ const AccountPage = () => {
     }
   };
 
+  if (authLoading) {
+    return <div className="container mt-4">Loading account information...</div>;
+  }
+
+  if (!user) {
+    return (
+      <div className="container mt-4">
+        <p>Please sign in to view your account settings.</p>
+        {/* Optionally, provide a Link component to the sign-in page */}
+        {/* <Link href="/signin">Go to Sign In</Link> */}
+      </div>
+    );
+  }
 
   return (
     <div className="container mt-4">


### PR DESCRIPTION
This commit addresses a TypeError during Vercel's prerendering of the /account page. The error "Cannot destructure property 'user' of '(0 , p.A)(...)' as it is null" was caused by the AuthContext not being available during server-side rendering and the page not robustly handling null user states.

Changes:
1. Modified `src/pages/_app.js` to wrap the main Component with `AuthProvider` from `src/context/AuthContext.jsx`. This ensures the auth context is available application-wide.
2. Updated `src/pages/account.js` to:
   - Use the `loading` state from `useAuth()`.
   - Display a loading message while `loading` is true.
   - Display a "Please sign in" message if not loading and `user` is null.
   - Ensured user-dependent operations and JSX are robust against null `user` objects.

Note: I am currently unable to test the build locally due to a persistent environment issue preventing `npm install` and `npm run build`.