### PR TITLE
Fix: Resolve BASE_URL environment variable error on /signin page

### DIFF
--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -302,7 +302,7 @@ const SignInPage = () => {
   );
 
   // Main Render
-  const bgImageUrl = `${import.meta.env.BASE_URL}assets/images/auth-background.png`;
+  const bgImageUrl = '/assets/images/auth-background.png';
   return (
     <>
       <div className="col-lg-6 d-none d-lg-flex flex-column justify-content-center align-items-start p-5 text-white position-relative" style={{ backgroundImage: `url(${bgImageUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }}>


### PR DESCRIPTION
This commit fixes a prerendering error on the /signin page: "TypeError: Cannot read properties of undefined (reading 'BASE_URL')"

The error was caused by the use of `import.meta.env.BASE_URL` to construct an image path in `src/pages/signin.js`. This is a Vite-specific feature and is not available in Next.js.

Changes:
- Modified `src/pages/signin.js` to use a root-relative path for the background image (`/assets/images/auth-background.png`) instead of relying on `import.meta.env.BASE_URL`.
- Verified that the image `auth-background.png` is correctly located in `public/assets/images/`, so the new path will resolve correctly.

This change should allow the Vercel build to proceed past the /signin page prerendering step.

Note: Local build testing continues to be blocked by a persistent environment issue preventing `npm install` and `npm run build`.