### PR TITLE
Fix: Apply styling to Sidebar and TopBar

### DIFF
--- a/src/components/layout/MainLayout.js
+++ b/src/components/layout/MainLayout.js
@@ -8,7 +8,7 @@ const MainLayout = ({ children }) => {
     <>
       <div className="d-flex main-layout-container"> {/* Flex container for sidebar and main content */}
         <Sidebar />
-        <div className="flex-grow-1 main-content-area"> {/* Main content area takes remaining space */}
+        <div className="flex-grow-1 main-content-area main-content"> {/* Main content area takes remaining space, added main-content */}
           <TopBar />
           <main className="p-3 page-content"> {/* Padding for content area */}
             {children}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,6 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/globals.css';
+import '../styles/style.css';
 import Head from 'next/head';
 import { AuthProvider } from '../context/AuthContext';
 import MainLayout from '../components/layout/MainLayout.js';


### PR DESCRIPTION
This commit addresses the issue of missing styles for the Sidebar and TopBar components.

Changes:
1. I modified `src/pages/_app.js` to include the main stylesheet by adding `import '../styles/style.css';`. This ensures that the custom styles defined in `style.css` are globally available.
2. I updated `src/components/layout/MainLayout.js`:
   - I added the class `main-content` to the primary content wrapper div. This class is targeted by `style.css` to apply a left margin, preventing the main content (including TopBar and page children) from being obscured by the fixed Sidebar.

These changes should restore the intended styling and layout for the Sidebar, TopBar, and the main application view.

Note: Local build testing continues to be blocked by a persistent environment issue.