### PR TITLE
Fix: Ensure 'Add New Property' modal displays correctly

### DIFF
--- a/src/components/modals/AddEditPropertyModal.js
+++ b/src/components/modals/AddEditPropertyModal.js
@@ -149,7 +149,6 @@ const AddEditPropertyModal = ({ isOpen, onClose, property, onSave }) => {
           </form>
         </div>
       </div>
-      {isOpen && <div className="modal-backdrop fade show"></div>}
     </div>
   );
 };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -5,10 +5,15 @@ import Head from 'next/head';
 import { AuthProvider } from '../context/AuthContext';
 import MainLayout from '../components/layout/MainLayout.js';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 export default function App({ Component, pageProps }) {
   const router = useRouter();
   const authPaths = ['/', '/404']; // Sign-in page and 404 page
+
+  useEffect(() => {
+    import('bootstrap/dist/js/bootstrap.bundle.min.js');
+  }, []);
 
   return (
     <AuthProvider>


### PR DESCRIPTION
This commit addresses an issue where clicking the 'Add New Property' button on the properties page would darken the screen (show a backdrop) but the modal itself would not appear.

Changes:
1. Modified `src/pages/_app.js`:
   - Added a `useEffect` hook to dynamically import `bootstrap/dist/js/bootstrap.bundle.min.js`. This ensures Bootstrap's JavaScript, which is required for full modal functionality (and other components like dropdowns), is loaded on the client-side.
2. Modified `src/components/modals/AddEditPropertyModal.js`:
   - Removed the manually rendered backdrop element (`<div className="modal-backdrop ..."></div>`). With Bootstrap's JS active, it will manage its own backdrop, and a manual one can cause conflicts.

These changes should allow the Bootstrap modal to function as intended, displaying correctly on top of its backdrop and being interactive.

Note: I'm still encountering a persistent environment issue that's preventing me from running a local build to test these changes.