### PR TITLE
Fix: Ensure user_id is included when saving properties

### DIFF
--- a/src/components/modals/AddEditPropertyModal.js
+++ b/src/components/modals/AddEditPropertyModal.js
@@ -145,7 +145,8 @@ const AddEditPropertyModal = ({ isOpen, onClose, property, onSave }) => {
         property_occupier: formData.property_occupier,
         property_details: formData.property_details,
         property_image_url: finalImageUrl, // finalImageUrl is determined before this block
-        company_id: companyId, // Add company_id here
+        company_id: companyId,
+        user_id: user.id, // Add user_id here
       };
 
       // Ensure numeric fields are numbers if your DB expects them (e.g., num_bedrooms)


### PR DESCRIPTION
This commit addresses the "null value in column 'user_id' of relation 'properties' violates not-null constraint" error that occurred when you tried to save a new property.

Changes in `src/components/modals/AddEditPropertyModal.js`:

1.  **Include `user_id` in Property Data**:
    *   The `handleSubmit` function has been updated to include `user_id: user.id` in the `propertyDataToSave` object.
    *   The `user.id` is obtained from the authenticated user via the `useAuth()` hook.
    *   This ensures that the `user_id` field in the `properties` table is populated with the ID of the user creating or updating the property.

This change ensures that the not-null constraint for `user_id` in the `properties` table is met, allowing properties to be saved correctly.