### PR TITLE
Fix: Correct column name in select and search logic

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -31,12 +31,12 @@ const PropertiesPage = () => {
 
       let query = supabase
         .from('properties')
-        .select('id, property_name, name, address, address_street, address_city, property_image_url, property_type, qr_code_image_url, created_at', { count: 'exact' })
+        .select('id, property_name, address, address_street, address_city, property_image_url, property_type, qr_code_image_url, created_at', { count: 'exact' })
         .order('created_at', { ascending: false })
         .range(from, to);
 
       if (searchQuery) {
-        query = query.or(`name.ilike.%${searchQuery}%,address_street.ilike.%${searchQuery}%`);
+        query = query.or(`property_name.ilike.%${searchQuery}%,address.ilike.%${searchQuery}%`);
       }
 
       const { data, error: dbError, count } = await query;


### PR DESCRIPTION
This commit addresses the "column properties.name does not exist" error and updates the property search functionality.

Changes in `src/pages/properties.js`:

1.  **Corrected Select Statement:**
    *   Removed the non-existent `name` column from the `select` statement in the `fetchProperties` function.
    *   The query now correctly fetches existing columns, including `property_name`.

2.  **Updated Search Logic:**
    *   Modified the search condition within `fetchProperties` to use `property_name` instead of `name`.
    *   The search now also uses the main `address` column for address-based searches, replacing the more specific `address_street`.
    *   The updated search filter is \`property_name.ilike.%\${searchQuery}%,address.ilike.%\${searchQuery}%\`.

These changes ensure that property data is fetched without errors and that the search functionality uses the correct and more comprehensive field names.