### PR TITLE
Fix: Remove address_street and address_city from properties handling

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -31,7 +31,7 @@ const PropertiesPage = () => {
 
       let query = supabase
         .from('properties')
-        .select('id, property_name, address, address_street, address_city, property_image_url, property_type, qr_code_image_url, created_at', { count: 'exact' })
+        .select('id, property_name, address, property_image_url, property_type, qr_code_image_url, created_at', { count: 'exact' })
         .order('created_at', { ascending: false })
         .range(from, to);
 


### PR DESCRIPTION
This commit removes references to the non-existent `address_street` and `address_city` columns from the `properties` table handling in `src/pages/properties.js`.

These fields were remnants from a previous data structure and have been fully replaced by the single `address` column for both data display and search functionality.

Changes in `src/pages/properties.js`:

1.  **Updated Select Statement:**
    *   Removed `address_street` and `address_city` from the `select`
      statement in the `fetchProperties` function. The query now only
      fetches defined columns.

2.  **Verified No Remaining References:**
    *   Ensured that no active code (display logic, search query)
      references `address_street` or `address_city`. The component
      now consistently uses the `address` field.

This resolves errors caused by attempting to select or query non-existent columns and ensures the component relies on the correct database schema.