### PR TITLE
Fix: Prevent navigation when admin buttons are clicked on cards

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -210,8 +210,16 @@ const PropertiesPage = () => {
                 </div>
                 {isAdmin && ( // Show Edit/Delete only to admins
                   <div className="card-footer bg-light d-flex justify-content-end">
-                      <button onClick={(e) => { e.stopPropagation(); handleOpenEditModal(property); }} className="btn btn-sm btn-outline-secondary me-2">Edit</button>
-                      <button onClick={(e) => { e.stopPropagation(); handleDeleteProperty(property.id); }} className="btn btn-sm btn-outline-danger">Delete</button>
+                      <button onClick={(e) => {
+                        e.preventDefault(); // Add this
+                        e.stopPropagation();
+                        handleOpenEditModal(property);
+                      }} className="btn btn-sm btn-outline-secondary me-2">Edit</button>
+                      <button onClick={(e) => {
+                        e.preventDefault(); // Add this
+                        e.stopPropagation();
+                        handleDeleteProperty(property.id);
+                      }} className="btn btn-sm btn-outline-danger">Delete</button>
                   </div>
                 )}
                 </a>


### PR DESCRIPTION
This commit addresses an issue where clicking the "Edit" or "Delete" buttons on a property card would perform the action but also inadvertently navigate to the property details page, due to the entire card being a link.

The fix involves updating the `onClick` handlers for these admin buttons in `src/pages/properties.js`.

Changes:
- Added `e.preventDefault()` to the `onClick` handlers for both the "Edit" and "Delete" buttons. This is in addition to the existing `e.stopPropagation()`.

The updated handlers ensure that the default link navigation behavior is prevented and the click event does not propagate to the parent card link. This allows the edit modal to open or the delete action to proceed without an unwanted redirect, while the rest of the card remains clickable for navigation.