### PR TITLE
Fix: Use first_name and last_name in Staff Page instead of full_name

### DIFF
--- a/src/pages/staff.js
+++ b/src/pages/staff.js
@@ -30,10 +30,10 @@ const StaffPage = () => {
     try {
       const from = (page - 1) * ITEMS_PER_PAGE; const to = from + ITEMS_PER_PAGE - 1;
       let query = supabase.from('profiles')
-        .select('id, full_name, email, role, user_status, profile_image_url, created_at', { count: 'exact' })
+        .select('id, first_name, last_name, email, role, user_status, profile_image_url, created_at', { count: 'exact' })
         .eq('company_id', user.app_metadata.company_id).eq('is_admin', false)
-        .order('full_name', { ascending: true });
-      if (searchQuery) query = query.or(`full_name.ilike.%${searchQuery}%,email.ilike.%${searchQuery}%`);
+        .order('first_name', { ascending: true }).order('last_name', { ascending: true });
+      if (searchQuery) query = query.or(`first_name.ilike.%${searchQuery}%,last_name.ilike.%${searchQuery}%,email.ilike.%${searchQuery}%`);
       if (roleFilter) query = query.eq('role', roleFilter);
       if (statusFilter) query = query.eq('user_status', statusFilter);
       query = query.range(from, to);
@@ -61,7 +61,8 @@ const StaffPage = () => {
   const handleDeleteStaff = async (staffMember) => { // Now takes full staffMember object
     if (!isAdmin) { alert("Permission denied."); return; }
     // For now, make it a status update to 'Inactive'
-    const confirmDeactivate = window.confirm(`Are you sure you want to set staff member ${staffMember.full_name || staffMember.email} to 'Inactive'?`);
+    const fullNameDisplay = `${staffMember.first_name || ''} ${staffMember.last_name || ''}`.trim();
+    const confirmDeactivate = window.confirm(`Are you sure you want to set staff member ${fullNameDisplay || staffMember.email} to 'Inactive'?`);
     if (confirmDeactivate) {
         setLoading(true);
         try {
@@ -96,8 +97,8 @@ const StaffPage = () => {
         <div className="table-responsive"><table className="table table-hover">
             <thead className="table-light"><tr><th>Profile</th><th>Name</th><th>Email</th><th>Role</th><th>Assigned Tasks</th><th>Status</th><th>Actions</th></tr></thead>
             <tbody>{staffList.map(staff => ( <tr key={staff.id}>
-                <td><img src={staff.profile_image_url || '/assets/images/placeholder-avatar.png'} alt={`${staff.full_name || 'Staff'}'s profile`} className="rounded-circle" style={{width: '40px', height: '40px', objectFit: 'cover'}} onError={(e)=>{e.target.src='/assets/images/placeholder-avatar.png';}} /></td>
-                <td>{staff.full_name || 'N/A'}</td><td>{staff.email}</td><td>{staff.role || 'N/A'}</td>
+                <td><img src={staff.profile_image_url || '/assets/images/placeholder-avatar.png'} alt={`${`${staff.first_name || ''} ${staff.last_name || ''}`.trim() || 'Staff'}'s profile`} className="rounded-circle" style={{width: '40px', height: '40px', objectFit: 'cover'}} onError={(e)=>{e.target.src='/assets/images/placeholder-avatar.png';}} /></td>
+                <td>{`${staff.first_name || ''} ${staff.last_name || ''}`.trim() || 'N/A'}</td><td>{staff.email}</td><td>{staff.role || 'N/A'}</td>
                 <td className="text-center">N/A</td>
                 <td><span className={`badge bg-${staff.user_status === 'Active' ? 'success' : (staff.user_status === 'Invited' || staff.user_status === 'New' ? 'warning text-dark' : 'secondary')}`}>{staff.user_status || 'N/A'}</span></td>
                 <td>{isAdmin && (<span> <button className="btn btn-sm btn-outline-secondary me-1" onClick={() => handleOpenEditModal(staff)} title="Edit"><i className="bi bi-pencil"></i></button> <button className="btn btn-sm btn-outline-danger" onClick={() => handleDeleteStaff(staff)} title="Deactivate"><i className="bi bi-person-x"></i></button> </span>)}</td>


### PR DESCRIPTION
This commit resolves the "column profiles.full_name does not exist" error on the Staff Management page (`src/pages/staff.js`) by updating the component to use separate `first_name` and `last_name` fields from the `profiles` table.

Changes in `src/pages/staff.js`:

1.  **Data Fetching (`fetchStaff`):**
    *   The Supabase `select` query now fetches `first_name` and
      `last_name` instead of the non-existent `full_name`.
    *   The search filter (`.or()` clause) has been updated to query
      against `first_name.ilike`, `last_name.ilike`, and `email.ilike`.
    *   The ordering of results is now primarily by `first_name`
      (ascending) and secondarily by `last_name` (ascending).

2.  **Display Logic:**
    *   Staff names in the table are now displayed by concatenating
      `staff.first_name` and `staff.last_name`.
    *   Profile image `alt` text and the deactivation confirmation
      message have also been updated to use the concatenated names.

These changes ensure the staff page correctly fetches, displays, searches, and sorts staff data based on the existing `first_name` and `last_name` columns in the `profiles` table.