### PR TITLE
Fix: Correct query for detailed_task_assignments on Tasks page

### DIFF
--- a/src/pages/tasks.js
+++ b/src/pages/tasks.js
@@ -45,8 +45,8 @@ const TasksPage = () => {
       // The `detailed_task_assignments` view should ideally contain all these.
       // Adding task_notes, task_description explicitly if they might not be in `*` from a minimal view.
       let query = supabase.from('detailed_task_assignments')
-        .select('*, tasks(task_notes, task_description)', { count: 'exact' })
-        .order('task_due_date', { ascending: true, nullsFirst: false }).range(from, to);
+        .select('*, tasks(task_notes, task_description, task_due_date)', { count: 'exact' })
+        .order('tasks.task_due_date', { ascending: true, nullsFirst: false }).range(from, to);
       if (statusFilter) query = query.eq('task_status', statusFilter);
       if (priorityFilter) query = query.eq('task_priority', priorityFilter);
       const { data, error: dbError, count } = await query; if (dbError) throw dbError;
@@ -118,7 +118,7 @@ const TasksPage = () => {
                   <td>{task.task_title}</td>
                   <td><span className={`badge rounded-pill badge-custom-${task.task_status?.toLowerCase().replace(/\s+/g,'-') || 'secondary'}`}>{task.task_status || 'N/A'}</span></td>
                   <td>{task.task_priority || 'N/A'}</td>
-                  <td>{task.task_due_date ? new Date(task.task_due_date).toLocaleDateString() : 'N/A'}</td>
+                  <td>{task.tasks?.task_due_date ? new Date(task.tasks.task_due_date).toLocaleDateString() : 'N/A'}</td>
                   <td>{task.assignee_full_name || task.assignee_email || 'Unassigned'}</td>
                   <td>
                     <button className="btn btn-sm btn-outline-primary me-1" onClick={() => handleOpenViewModal(task)}><i className="bi bi-eye"></i></button>


### PR DESCRIPTION
This commit resolves errors on the Tasks page (`src/pages/tasks.js`) related to fetching `task_due_date`, `task_notes`, and `task_description`. These columns are properties of the main `tasks` table, not directly of the `detailed_task_assignments` view.

Changes in `src/pages/tasks.js` within the `fetchTasks` function:

1.  **Updated Select Statement:**
    *   The query for `detailed_task_assignments` now correctly fetches
      `task_due_date`, `task_notes`, and `task_description` from the
      related `tasks` table using the nested selection syntax:
      `select('*, tasks(task_notes, task_description, task_due_date)')`.

2.  **Updated Order Clause:**
    *   The ordering is now correctly applied to the nested `task_due_date`
      field: `.order('tasks.task_due_date', { ascending: true, nullsFirst: false })`.

3.  **Updated Display Logic:**
    *   The table cell rendering for "Due Date" now accesses the nested
      property: `task.tasks.task_due_date`.

These changes ensure that task details are fetched and displayed correctly, and that sorting by due date functions as intended. This also addresses the "column detailed_task_assignments.task_due_date does not exist" (and similar for notes/description) errors.