### PR TITLE
Fix: Correct property address display and view definition

### DIFF
--- a/src/pages/tasks.js
+++ b/src/pages/tasks.js
@@ -114,7 +114,7 @@ const TasksPage = () => {
             <thead className="table-light"><tr><th>Property</th><th>Title</th><th>Status</th><th>Priority</th><th>Due Date</th><th>Assigned To</th><th>Actions</th></tr></thead>
             <tbody>{tasks.map(task => (
                 <tr key={task.task_id}>
-                  <td>{task.property_address_street || 'N/A'}{task.property_address_city ? `, ${task.property_address_city}` : ''}</td>
+                  <td>{task.address || 'N/A'}</td>
                   <td>{task.task_title}</td>
                   <td><span className={`badge rounded-pill badge-custom-${task.task_status?.toLowerCase().replace(/\s+/g,'-') || 'secondary'}`}>{task.task_status || 'N/A'}</span></td>
                   <td>{task.task_priority || 'N/A'}</td>

--- a/src/supabase/migrations/20240514103800_create_detailed_task_assignments_view.sql
+++ b/src/supabase/migrations/20240514103800_create_detailed_task_assignments_view.sql
@@ -23,10 +23,7 @@ SELECT
     p.email AS assignee_email,
     prop.id AS property_id,
     prop.property_name AS property_name,
-    prop.address_street AS property_address_street,
-    prop.address_city AS property_address_city,
-    prop.address_postal_code AS property_address_postal_code,
-    prop.address_country AS property_address_country
+    prop.address AS address
 FROM
     public.task_assignments ta
 JOIN


### PR DESCRIPTION
This commit addresses an issue with how property addresses were handled:

1. Updated `detailed_task_assignments` view:
    - Modified `src/supabase/migrations/20240514103800_create_detailed_task_assignments_view.sql`.
    - The view now selects `prop.address AS address` from the `properties` table instead of attempting to select non-existent `address_street`, `address_city`, etc. columns. This aligns with the actual schema of the `properties` table.

2. Updated frontend display:
    - Modified `src/pages/tasks.js`.
    - The `TasksPage` component now displays the property address using the `task.address` field provided by the updated view.

These changes ensure that property addresses are correctly fetched from the database and displayed on the tasks page. This commit supersedes the previous attempt which used incorrect address field names.