### PR TITLE
Fix: Resolve Vercel SSR build error `document is not defined`

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,15 +1,19 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/globals.css';
 import '../styles/style.css';
-import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 import Head from 'next/head';
 import { AuthProvider } from '../context/AuthContext';
 import MainLayout from '../components/layout/MainLayout.js';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 export default function App({ Component, pageProps }) {
   const router = useRouter();
   const authPaths = ['/', '/404']; // Sign-in page and 404 page
+
+  useEffect(() => {
+    import('bootstrap/dist/js/bootstrap.bundle.min.js');
+  }, []);
 
   return (
     <AuthProvider>


### PR DESCRIPTION
This commit reverts the Bootstrap JS import strategy in `src/pages/_app.js` to fix a server-side rendering (SSR) error during Vercel deployment.

- Removed the top-level static import of `bootstrap/dist/js/bootstrap.bundle.min.js`.
- Reinstated the dynamic import within a `useEffect` hook.

This ensures that Bootstrap's JavaScript, which relies on `document` and `window` objects, is only imported on the client-side, preventing the `ReferenceError: document is not defined` during the build process.