### PR TITLE
Debug: Add console logs to modal useEffect

### DIFF
--- a/src/components/modals/CreateEditTaskModal.jsx
+++ b/src/components/modals/CreateEditTaskModal.jsx
@@ -178,21 +178,27 @@ const CreateEditTaskModal = ({ isOpen, onClose, task, onSave, propertiesList, st
   const handleClose = () => { onClose(); };
 
   useEffect(() => {
+    console.log('[CreateEditTaskModal] useEffect triggered. isOpen:', isOpen, 'Ref:', modalRef.current);
     const modalElement = modalRef.current;
     if (!modalElement) return;
 
     if (!window.bootstrap || !window.bootstrap.Modal) {
+      console.log('[CreateEditTaskModal] Bootstrap Modal JS not available yet.');
       return;
     }
 
+    console.log('[CreateEditTaskModal] window.bootstrap:', window.bootstrap);
+    console.log('[CreateEditTaskModal] window.bootstrap.Modal:', window.bootstrap ? window.bootstrap.Modal : 'undefined');
     const bsModal = new window.bootstrap.Modal(modalElement);
 
     if (isOpen) {
+      console.log('[CreateEditTaskModal] Attempting to call bsModal.show()');
       bsModal.show();
     } else {
       try {
           const currentModalInstance = window.bootstrap.Modal.getInstance(modalElement);
-          if (currentModalInstance) {
+          if (currentModalInstance && currentModalInstance._isShown) { // Check if shown
+               console.log('[CreateEditTaskModal] Attempting to call bsModal.hide()');
                currentModalInstance.hide();
           }
       } catch (e) {

--- a/src/components/modals/ViewTaskModal.jsx
+++ b/src/components/modals/ViewTaskModal.jsx
@@ -102,21 +102,27 @@ const ViewTaskModal = ({ isOpen, onClose, task, onAttachmentDeleted, onTaskUpdat
   };
 
   useEffect(() => {
+    console.log('[ViewTaskModal] useEffect triggered. isOpen:', isOpen, 'Ref:', modalRef.current);
     const modalElement = modalRef.current;
     if (!modalElement) return;
 
     if (!window.bootstrap || !window.bootstrap.Modal) {
+      console.log('[ViewTaskModal] Bootstrap Modal JS not available yet.');
       return;
     }
 
+    console.log('[ViewTaskModal] window.bootstrap:', window.bootstrap);
+    console.log('[ViewTaskModal] window.bootstrap.Modal:', window.bootstrap ? window.bootstrap.Modal : 'undefined');
     const bsModal = new window.bootstrap.Modal(modalElement);
 
     if (isOpen) {
+      console.log('[ViewTaskModal] Attempting to call bsModal.show()');
       bsModal.show();
     } else {
       try {
           const currentModalInstance = window.bootstrap.Modal.getInstance(modalElement);
-          if (currentModalInstance) {
+          if (currentModalInstance && currentModalInstance._isShown) { // Check if shown
+               console.log('[ViewTaskModal] Attempting to call bsModal.hide()');
                currentModalInstance.hide();
           }
       } catch (e) {


### PR DESCRIPTION
I've added console.log statements to the main useEffect hook (responsible for show/hide logic) within ViewTaskModal.jsx and CreateEditTaskModal.jsx.

These logs will help you verify:
- If the useEffect is triggered when the isOpen prop changes.
- The availability of window.bootstrap and window.bootstrap.Modal.
- If the bsModal.show() or bsModal.hide() methods are being reached.

This is for diagnosing why modals may not be appearing as expected.