### PR TITLE
Fix: Implement robust Bootstrap JS initialization in modals

### DIFF
--- a/src/components/modals/CreateEditTaskModal.jsx
+++ b/src/components/modals/CreateEditTaskModal.jsx
@@ -13,6 +13,7 @@ const generateStoragePath = (userId, taskId, file) => {
 
 const CreateEditTaskModal = ({ isOpen, onClose, task, onSave, propertiesList, staffList }) => {
   const modalRef = useRef(null);
+  const modalInstanceRef = useRef(null);
   const { user } = useAuth(); // User needed for uploaded_by and storage path
   const [formData, setFormData] = useState({
     property_id: '', title: '', description: '', status: 'New',
@@ -178,48 +179,79 @@ const CreateEditTaskModal = ({ isOpen, onClose, task, onSave, propertiesList, st
   const handleClose = () => { onClose(); };
 
   useEffect(() => {
-    console.log('[CreateEditTaskModal] useEffect triggered. isOpen:', isOpen, 'Ref:', modalRef.current);
     const modalElement = modalRef.current;
-    if (!modalElement) return;
-
-    if (!window.bootstrap || !window.bootstrap.Modal) {
-      console.log('[CreateEditTaskModal] Bootstrap Modal JS not available yet.');
+    // If the modal element isn't available yet, or if the modal isn't supposed to be open, do nothing.
+    if (!modalElement) {
+      console.log('[CreateEditTaskModal] Modal element ref is null, cannot proceed.');
       return;
     }
 
-    console.log('[CreateEditTaskModal] window.bootstrap:', window.bootstrap);
-    console.log('[CreateEditTaskModal] window.bootstrap.Modal:', window.bootstrap ? window.bootstrap.Modal : 'undefined');
-    const bsModal = new window.bootstrap.Modal(modalElement);
+    if (!isOpen) {
+      // If the modal is supposed to be closed:
+      // Hide and dispose of the modal instance if it exists and is shown.
+      if (modalInstanceRef.current) {
+        console.log('[CreateEditTaskModal] isOpen is false. Hiding and disposing modal.');
+        // Check if modal is shown before trying to hide to prevent errors
+        const bsInstance = window.bootstrap.Modal.getInstance(modalElement);
+        if (bsInstance && bsInstance._isShown) {
+          bsInstance.hide();
+        }
+        modalInstanceRef.current.dispose(); // Dispose the instance we stored
+        modalInstanceRef.current = null;
+      }
+      return; // Early exit if modal is not supposed to be open
+    }
 
-    if (isOpen) {
-      console.log('[CreateEditTaskModal] Attempting to call bsModal.show()');
-      bsModal.show();
-    } else {
-      try {
-          const currentModalInstance = window.bootstrap.Modal.getInstance(modalElement);
-          if (currentModalInstance && currentModalInstance._isShown) { // Check if shown
-               console.log('[CreateEditTaskModal] Attempting to call bsModal.hide()');
-               currentModalInstance.hide();
-          }
-      } catch (e) {
-        // console.warn("Error hiding modal:", e);
+    // If isOpen is true, proceed to initialize and show:
+    let attempts = 0;
+    const maxAttempts = 20; // Try for up to 2 seconds (20 * 100ms)
+    const intervalTime = 100; // ms
+    let pollerTimeoutId = null;
+
+    function tryInitializeModal() {
+      console.log(`[CreateEditTaskModal] Attempting to initialize modal (attempt ${attempts + 1}). isOpen:`, isOpen);
+
+      if (window.bootstrap && window.bootstrap.Modal) {
+        console.log('[CreateEditTaskModal] Bootstrap is NOW available.');
+        if (!modalInstanceRef.current) { // Create new instance only if one doesn't exist or was disposed
+          modalInstanceRef.current = new window.bootstrap.Modal(modalElement);
+          modalElement.addEventListener('hidden.bs.modal', () => {
+            // This event listener helps sync state if the modal is closed by Bootstrap (e.g., ESC key)
+            console.log('[CreateEditTaskModal] hidden.bs.modal event triggered.');
+            if (isOpen && onClose) { // Check React's state (isOpen) before calling onClose
+              onClose();
+            }
+          });
+        }
+        console.log('[CreateEditTaskModal] Attempting to call modalInstanceRef.current.show()');
+        modalInstanceRef.current.show();
+      } else {
+        attempts++;
+        if (attempts < maxAttempts) {
+          console.warn(`[CreateEditTaskModal] Bootstrap Modal JS not available (attempt ${attempts}). Retrying in ${intervalTime}ms...`);
+          pollerTimeoutId = setTimeout(tryInitializeModal, intervalTime);
+        } else {
+          console.error('[CreateEditTaskModal] Bootstrap Modal JS did not load after multiple attempts.');
+        }
       }
     }
 
-    const handleExternalClose = () => {
-      if (isOpen) {
-        onClose();
-      }
-    };
-    modalElement.addEventListener('hidden.bs.modal', handleExternalClose);
+    // Start the process if the modal is supposed to be open
+    tryInitializeModal();
 
+    // Cleanup function
     return () => {
-      modalElement.removeEventListener('hidden.bs.modal', handleExternalClose);
-      if (window.bootstrap && window.bootstrap.Modal) {
-          const currentModalInstance = window.bootstrap.Modal.getInstance(modalElement);
-          if (currentModalInstance) {
-              currentModalInstance.dispose();
-          }
+      console.log('[CreateEditTaskModal] useEffect cleanup. isOpen:', isOpen);
+      clearTimeout(pollerTimeoutId); // Clear any pending timeout from the poller
+
+      if (modalInstanceRef.current) {
+        console.log('[CreateEditTaskModal] Disposing modal instance in cleanup.');
+        const bsInstance = window.bootstrap.Modal.getInstance(modalElement);
+        if (bsInstance && bsInstance._isShown) {
+           bsInstance.hide();
+        }
+        modalInstanceRef.current.dispose();
+        modalInstanceRef.current = null;
       }
     };
   }, [isOpen, onClose]);


### PR DESCRIPTION
Refactored ViewTaskModal.jsx and CreateEditTaskModal.jsx to ensure they correctly initialize and manage Bootstrap modal instances, even if Bootstrap's JS loads asynchronously.

Changes include:
- Implemented a polling mechanism within the modal components' useEffect hook. If window.bootstrap.Modal is not immediately available when a modal is opened, the component now retries initialization for a short period.
- Improved modal instance management (creation, storage in ref, and disposal) to prevent conflicts and ensure proper cleanup.
- Added event listeners for 'hidden.bs.modal' to better synchronize React state when modals are closed via Bootstrap's native mechanisms (e.g., ESC key, backdrop click).
- Included detailed console logging for diagnosing the modal initialization process.

This addresses issues where modals would not appear or would cause the page to be unresponsive due to timing conflicts with Bootstrap JS loading.