### PR TITLE
Refactor: Remove bootstrap.bundle.min.js

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -11,9 +11,7 @@ export default function App({ Component, pageProps }) {
   const router = useRouter();
   const authPaths = ['/', '/404']; // Sign-in page and 404 page
 
-  useEffect(() => {
-    import('bootstrap/dist/js/bootstrap.bundle.min.js');
-  }, []);
+  // Removed useEffect for Bootstrap JS import
 
   return (
     <AuthProvider>


### PR DESCRIPTION
I removed the dynamic import of `bootstrap.bundle.min.js` from `_app.js`. This change is made as all relevant JavaScript-driven components (modals, dropdowns) have been migrated to use `react-bootstrap` equivalents, which manage their own JavaScript logic and do not rely on the global Bootstrap bundle.

The Bootstrap CSS (`bootstrap.min.css`) import remains, as it is still required for styling the `react-bootstrap` components and other Bootstrap classes used throughout the application.

This completes the transition away from vanilla Bootstrap JavaScript, aiming for a more React-idiomatic and robust component implementation.