### PR TITLE
Feat: UI Overhaul Phase 2 - TopBar and Page Headers

### DIFF
--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { forwardRef } from 'react'; // Added forwardRef
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
+import Dropdown from 'react-bootstrap/Dropdown';
 
 const getIconForPath = (path, iconClassName) => {
   switch (path) {
@@ -40,9 +41,26 @@ const getIconForPath = (path, iconClassName) => {
   }
 };
 
+// Define CustomToggle for the Dropdown
+const CustomToggle = forwardRef(({ children, onClick }, ref) => (
+  <button
+    ref={ref}
+    onClick={(e) => {
+      e.preventDefault();
+      onClick(e);
+    }}
+    // Apply existing Tailwind classes from the button that was replaced
+    className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:hover:bg-accent/50 size-9 h-8 w-8 text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-all duration-200 flex-shrink-0"
+    aria-label="User menu options"
+  >
+    {children}
+  </button>
+));
+CustomToggle.displayName = 'CustomToggle';
+
 const Sidebar = () => {
   const router = useRouter();
-  const { isAdmin, loading: authLoading, user } = useAuth();
+  const { isAdmin, loading: authLoading, user, signOut } = useAuth(); // Added signOut
 
   const isActive = (path) => router.pathname === path;
 
@@ -75,6 +93,11 @@ const Sidebar = () => {
     name: "Alex Johnson",
     email: "alex.johnson@example.com",
     avatarUrl: "https://randomuser.me/api/portraits/men/32.jpg"
+  };
+
+  const handleSignOut = async () => {
+    await signOut();
+    router.push('/'); // Redirect to SignIn page
   };
 
   return (
@@ -131,9 +154,26 @@ const Sidebar = () => {
               <h3 className="font-semibold text-slate-900 text-sm truncate leading-tight">{profileUser.name || (user ? (user.user_metadata?.first_name || 'User') : 'Guest')}</h3>
               <p className="text-xs text-slate-500 truncate leading-relaxed mt-0.5">{user ? user.email : 'Not logged in'}</p>
             </div>
-            <button className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:hover:bg-accent/50 size-9 h-8 w-8 text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-all duration-200 flex-shrink-0" aria-label="User menu options">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-ellipsis-vertical h-4 w-4"><circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle></svg>
-            </button>
+            <Dropdown align="end" drop="up">
+              <Dropdown.Toggle as={CustomToggle} id="sidebar-user-options">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-ellipsis-vertical h-4 w-4">
+                  <circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle>
+                </svg>
+              </Dropdown.Toggle>
+              <Dropdown.Menu className="shadow-lg mb-2">
+                <Dropdown.Item as={Link} href="/account" legacyBehavior={false}>
+                  <a className="dropdown-item flex items-center gap-2">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-settings w-4 h-4"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.1a2 2 0 0 1-1-1.72v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+                    Account Settings
+                  </a>
+                </Dropdown.Item>
+                <Dropdown.Divider />
+                <Dropdown.Item onClick={handleSignOut} className="text-danger flex items-center gap-2">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-log-out w-4 h-4"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" x2="9" y1="12" y2="12"></line></svg>
+                  Sign Out
+                </Dropdown.Item>
+              </Dropdown.Menu>
+            </Dropdown>
           </div>
         </div>
         <div className="pt-3 border-t border-slate-200">

--- a/src/components/layout/TopBar.js
+++ b/src/components/layout/TopBar.js
@@ -1,88 +1,38 @@
-import React, { useState, useEffect } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { useAuth } from '../../context/AuthContext'; // Import useAuth
-import Dropdown from 'react-bootstrap/Dropdown';
+import React from 'react'; // Removed useState, useEffect, Link, useRouter, useAuth, Dropdown
 
 const TopBar = () => {
-  const router = useRouter();
-  const { user, isAdmin, signOut } = useAuth(); // Get signOut from AuthContext
-
-  const [pageTitle, setPageTitle] = useState('Dashboard');
-  // const [isDropdownOpen, setIsDropdownOpen] = useState(false); // Removed
+  // Removed router, user, isAdmin, signOut, pageTitle, useEffect for page title, handleSignOut
 
   const handleSidebarToggle = () => {
     document.getElementById('sidebar')?.classList.toggle('active-sidebar');
     document.querySelector('.sidebar-overlay')?.classList.toggle('active-sidebar');
   };
 
-  const handleSignOut = async () => {
-    const { error } = await signOut(); // Call signOut from AuthContext
-    if (error) {
-      console.error('Error signing out:', error);
-      // Optionally display an error to the user using a toast or alert component
-    } else {
-      router.push('/'); // Redirect to SignIn page (root) after sign out
-    }
-  };
-
-  useEffect(() => {
-    const pathTitleMapping = {
-      '/dashboard': 'Dashboard',
-      '/properties': 'Properties',
-      '/tasks': 'Tasks',
-      '/staff': 'Staff',
-      '/notifications': 'Notifications',
-      '/account': 'Account Settings',
-      '/agency-setup': 'Agency Setup',
-      '/property-details/:propertyId': 'Property Details'
-    };
-    // Match dynamic routes like /property-details/:propertyId
-    let title = 'Property Hub';
-    for (const key in pathTitleMapping) {
-      const regex = new RegExp(`^${key.replace(/:\w+/g, '[^/]+')}$`);
-      if (regex.test(router.pathname)) {
-        title = pathTitleMapping[key];
-        break;
-      }
-    }
-    setPageTitle(title);
-  }, [router.pathname]);
-
   // Access Denied Modal Logic removed from TopBar as it's handled in MainLayout
 
   return (
-    <div className="top-bar">
+    //Topbar is now only for mobile, to toggle the sidebar.
+    //It's sticky, has a backdrop blur, shadow, and border. Hidden on md screens and up.
+    <div className="sticky top-0 z-30 flex md:hidden items-center justify-between p-3 bg-white/80 backdrop-blur-xl shadow-lg border-b border-white/20">
+      {/* This button is specifically for mobile to toggle the sidebar */}
       <button
-        className="btn d-lg-none me-2"
+        className="btn text-slate-900 p-1" // Adjusted padding for better touch target
         type="button"
-        id="sidebarToggler"
+        id="sidebarToggler" // This ID is used by the JS functions
         aria-label="Toggle sidebar"
         onClick={handleSidebarToggle}
       >
-        <i className="bi bi-list"></i>
+        {/* Using a larger icon for better visibility on mobile */}
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-panel-left-open w-6 h-6">
+            <rect width="18" height="18" x="3" y="3" rx="2"></rect>
+            <path d="M9 3v18"></path>
+            <path d="m14 9 3 3-3 3"></path>
+        </svg>
       </button>
-      <div className="page-title">
-        <span data-i18n={`${pageTitle.toLowerCase().replace(' ', '')}Page.header`}>{pageTitle}</span>
-      </div>
-      <div className="top-bar-icons d-flex align-items-center">
-        <Link href="/notifications" legacyBehavior={false}><a className="nav-link"><i className="bi bi-bell-fill"></i></a></Link>
-
-        <Dropdown align="end">
-          <Dropdown.Toggle variant="link" id="dropdown-user-settings" className="dropdown-toggle-no-caret p-0">
-            <i className="bi bi-person-gear" style={{ fontSize: '1.5em', color: '#6B7280' }}></i>
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            <Dropdown.Item as={Link} href="/account" legacyBehavior={false}>
-              <i className="bi bi-gear-fill me-2"></i>Account Settings
-            </Dropdown.Item>
-            <Dropdown.Divider />
-            <Dropdown.Item onClick={handleSignOut} style={{ color: 'red' }}>
-              <i className="bi bi-box-arrow-right me-2"></i>Sign Out
-            </Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
-      </div>
+      {/* Placeholder for a mobile logo or title if needed, otherwise empty */}
+      <div></div>
+      {/* Placeholder for any right-aligned mobile icons if needed, otherwise empty */}
+      <div></div>
     </div>
   );
 };

--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -142,94 +142,147 @@ const PropertiesPage = () => {
   // Keep error display prominent
   if (error && properties.length === 0) return <p className="container mt-4 text-danger">Error fetching properties: {error}</p>;
 
-
   return (
-    <div className="container-fluid properties-page-content pt-3">
-      <div className="d-flex justify-content-between align-items-center pb-2 mb-3 border-bottom">
-        <h1 className="h2" data-i18n="propertiesPage.title">Properties</h1>
-        {isAdmin && ( // Show Add button only to admins
-          <div className="btn-toolbar mb-2 mb-md-0">
-            <button type="button" className="btn btn-primary" onClick={handleOpenAddModal} data-i18n="propertiesPage.addNewButton">
-              <i className="bi bi-plus-lg me-1"></i> Add New Property
-            </button>
+    // Main container for the page, Tailwind classes can be added here if needed for overall page background or max-width etc.
+    // For now, assuming MainLayout handles overall page chrome.
+    <>
+      <header className="sticky top-6 z-40 mx-6 mb-8"> {/* Adjusted top to align with sidebar's top-6, assuming topbar is gone or different */}
+        <div className="backdrop-blur-xl bg-white/80 border border-white/20 rounded-2xl shadow-xl shadow-black/5 p-6">
+          <div className="flex flex-col lg:flex-row gap-4 lg:items-center lg:justify-between">
+            <div className="flex flex-col sm:flex-row gap-4 flex-1">
+              <div className="relative flex-1 max-w-md">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-search absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400">
+                  <circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path>
+                </svg>
+                <input
+                  type="text"
+                  className="file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring hover:bg-muted/50 inline-flex h-10 w-full items-center justify-center whitespace-nowrap rounded-xl border-0 bg-transparent px-3 py-2 text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 pl-10 bg-white/60 border-slate-200 focus:bg-white"
+                  placeholder="Search properties..."
+                  value={searchQuery}
+                  onChange={handleSearchChange}
+                />
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => console.log('Filter clicked')}
+                  className="inline-flex items-center justify-center whitespace-nowrap rounded-xl border border-slate-200 bg-white/60 px-3 py-2 text-sm font-medium text-slate-700 ring-offset-background transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 gap-1.5"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-filter w-4 h-4">
+                    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
+                  </svg>
+                  Filter
+                </button>
+                <div className="flex rounded-lg border border-slate-200 bg-white/60 p-1">
+                  <button
+                    onClick={() => console.log('Grid view clicked')}
+                    className="inline-flex items-center justify-center whitespace-nowrap rounded-lg px-2.5 py-1.5 text-sm font-medium text-slate-700 ring-offset-background transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-slate-100"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-layout-grid w-4 h-4">
+                      <rect width="7" height="7" x="3" y="3" rx="1"></rect><rect width="7" height="7" x="14" y="3" rx="1"></rect><rect width="7" height="7" x="14" y="14" rx="1"></rect><rect width="7" height="7" x="3" y="14" rx="1"></rect>
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => console.log('List view clicked')}
+                    className="inline-flex items-center justify-center whitespace-nowrap rounded-lg px-2.5 py-1.5 text-sm font-medium text-slate-700 ring-offset-background transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-list w-4 h-4">
+                      <line x1="8" x2="21" y1="6" y2="6"></line><line x1="8" x2="21" y1="12" y2="12"></line><line x1="8" x2="21" y1="18" y2="18"></line><line x1="3" x2="3.01" y1="6" y2="6"></line><line x1="3" x2="3.01" y1="12" y2="12"></line><line x1="3" x2="3.01" y1="18" y2="18"></line>
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+            {isAdmin && (
+              <button
+                onClick={handleOpenAddModal}
+                className="inline-flex items-center justify-center whitespace-nowrap rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white ring-offset-background transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 shadow-lg shadow-blue-500/20 gap-1.5"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-plus w-4 h-4">
+                  <path d="M5 12h14"></path><path d="M12 5v14"></path>
+                </svg>
+                Add Property
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <section className="px-6 pb-12">
+        <div className="mb-8">
+          <h2 className="text-3xl font-bold text-slate-900 mb-2" data-i18n="propertiesPage.title">Properties</h2>
+          <p className="text-slate-600 max-w-2xl" data-i18n="propertiesPage.description">Manage and monitor all your properties from one central dashboard. Track maintenance tasks, view property details, and stay organized.</p>
+        </div>
+
+        {error && <div className="alert alert-danger">Error: {error}</div>}
+        {/* loading state is handled by the initial page load check */}
+        {/* {!loading && properties.length === 0 below handles no properties after load */}
+
+        {!loading && properties.length === 0 ? (
+          <p data-i18n="propertiesPage.noPropertiesFound">No properties found.</p>
+        ) : (
+          <div className="row g-4" id="propertyCardsContainer"> {/* Using Bootstrap grid classes for cards for now */}
+            {properties.map(property => (
+              <div className="col-lg-4 col-md-6 mb-4" key={property.id}>
+                <Link href={`/property-details/${property.id}`} passHref legacyBehavior>
+                  <a className="card property-card-link h-100 shadow-sm text-decoration-none d-block"> {/* These are Bootstrap card classes */}
+                    <img
+                      src={property.property_image_url || '/assets/images/card1.png'}
+                      className="card-img-top property-card-img"
+                      alt={`Property ${property.property_name || 'Unnamed'}`}
+                      onError={(e) => { e.target.onerror = null; e.target.src='/assets/images/card_placeholder.png'; }}
+                    />
+                    <div className="card-body d-flex flex-column">
+                      <h5 className="card-title text-primary">{property.property_name || 'N/A'}</h5>
+                      <p className="card-text text-secondary flex-grow-1">
+                        {property.address || 'N/A'}
+                      </p>
+                      <p className="card-text">
+                        <small className="text-muted">Type: {property.property_type || 'N/A'}</small>
+                      </p>
+                      <div className="mt-auto d-flex justify-content-between align-items-center pt-2">
+                        {property.qr_code_image_url && (
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline-secondary qr-code-button"
+                            title="Show QR Code"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              handleShowQrCode(property.qr_code_image_url, property.property_name);
+                            }}
+                          >
+                            <i className="bi bi-qr-code"></i>
+                          </button>
+                        )}
+                         {/* Replaced span with a more descriptive text or keep as is if design implies icon only */}
+                        <span className="text-primary small fw-medium">View Details</span>
+                      </div>
+                    </div>
+                    {isAdmin && (
+                      <div className="card-footer bg-light d-flex justify-content-end">
+                          <button onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            handleOpenEditModal(property);
+                          }} className="btn btn-sm btn-outline-secondary me-2">Edit</button>
+                          <button onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            handleDeleteProperty(property.id);
+                          }} className="btn btn-sm btn-outline-danger">Delete</button>
+                      </div>
+                    )}
+                  </a>
+                </Link>
+              </div>
+            ))}
           </div>
         )}
-      </div>
+         {/* Loading indicator for infinite scroll */}
+        {loading && properties.length > 0 && <p className="text-center mt-4">Loading more properties...</p>}
 
-      <div className="row mb-3">
-        <div className="col-md-4">
-          <input type="text" className="form-control" placeholder="Search by name or address..." value={searchQuery} onChange={handleSearchChange} />
-        </div>
-      </div>
 
-      {error && <div className="alert alert-danger">Error: {error}</div>}
-      {loading && <p>Loading...</p>}
-
-      {!loading && properties.length === 0 ? (
-        <p data-i18n="propertiesPage.noPropertiesFound">No properties found.</p>
-      ) : (
-        <div className="row g-4" id="propertyCardsContainer">
-          {properties.map(property => (
-            <div className="col-lg-4 col-md-6 mb-4" key={property.id}>
-              <Link href={`/property-details/${property.id}`} passHref legacyBehavior>
-                <a className="card property-card-link h-100 shadow-sm text-decoration-none d-block">
-                  <img
-                    src={property.property_image_url || '/assets/images/card1.png'}
-                  className="card-img-top property-card-img"
-                  alt={`Property ${property.property_name || 'Unnamed'}`}
-                  onError={(e) => { e.target.onerror = null; e.target.src='/assets/images/card_placeholder.png'; }}
-                />
-                <div className="card-body d-flex flex-column">
-                  <h5 className="card-title text-primary">{property.property_name || 'N/A'}</h5>
-                  <p className="card-text text-secondary flex-grow-1">
-                    {property.address || 'N/A'}
-                  </p>
-                  <p className="card-text">
-                    <small className="text-muted">Type: {property.property_type || 'N/A'}</small>
-                  </p>
-                  <div className="mt-auto d-flex justify-content-between align-items-center pt-2">
-                    {property.qr_code_image_url && (
-                      <button
-                        type="button"
-                        className="btn btn-sm btn-outline-secondary qr-code-button"
-                        title="Show QR Code"
-                        data-qr-url={property.qr_code_image_url}
-                        data-property-name={property.property_name}
-                        onClick={(e) => {
-                          e.preventDefault(); // Added
-                          e.stopPropagation();
-                          handleShowQrCode(property.qr_code_image_url, property.property_name);
-                        }}
-                        // data-i18n="propertiesPage.card.showQrButton" // data-i18n can be added if needed
-                      >
-                        <i className="bi bi-qr-code"></i>
-                      </button>
-                    )}
-                    <span className="btn btn-sm btn-outline-primary align-self-start">View Details</span>
-                  </div>
-                </div>
-                {isAdmin && ( // Show Edit/Delete only to admins
-                  <div className="card-footer bg-light d-flex justify-content-end">
-                      <button onClick={(e) => {
-                        e.preventDefault(); // Add this
-                        e.stopPropagation();
-                        handleOpenEditModal(property);
-                      }} className="btn btn-sm btn-outline-secondary me-2">Edit</button>
-                      <button onClick={(e) => {
-                        e.preventDefault(); // Add this
-                        e.stopPropagation();
-                        handleDeleteProperty(property.id);
-                      }} className="btn btn-sm btn-outline-danger">Delete</button>
-                  </div>
-                )}
-                </a>
-              </Link>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Pagination controls removed for infinite scroll */}
+      </section>
 
       {isModalOpen && (
         <AddEditPropertyModal


### PR DESCRIPTION
This commit implements significant UI changes based on the new Tailwind CSS design direction:

1.  **TopBar.js Refactored:**
    - The global TopBar is now minimal and mobile-only, containing only the sidebar toggle button.
    - Styled with Tailwind CSS for a floating/blur effect, appearing sticky at the top on mobile screens (`md:hidden`).
    - Page title and other global icons (notifications, old user menu) have been removed from it.

2.  **User Settings/Logout Relocated to Sidebar.js:**
    - The user profile block at the bottom of the new Tailwind sidebar now features a `react-bootstrap/Dropdown` triggered by an ellipsis icon.
    - This dropdown contains links to "Account Settings" and a "Sign Out" function.

3.  **Page-Specific Header on Properties Page:**
    - Implemented a new styled header within `src/pages/properties.js` using Tailwind CSS, based on the provided HTML snippet.
    - This header is sticky (`top-6`), has a backdrop blur/floating appearance, and includes the page title ("Properties"), a description, a search bar (wired to existing state), placeholder filter/view buttons, and a functional "Add Property" button.

4.  **MainLayout.js Adjusted:**
    - Confirmed that the main content wrapper in `MainLayout.js` has the correct `md:ml-[calc(16rem+1.5rem)]` to accommodate the always-visible floating sidebar on desktop.
    - The layout now supports the mobile-only minimal TopBar and page-specific headers.

This phase aims to declutter the global UI, provide a modern page header structure using Tailwind CSS, and improve the separation of global versus page-specific controls.