### PR TITLE
Fix: Correct JSX syntax error in PropertiesPage

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -301,7 +301,7 @@ const PropertiesPage = () => {
           propertyName={currentQrPropertyName}
         />
       )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Resolved a Vercel build failure caused by a mismatched JSX closing tag in `src/pages/properties.js`. An opening JSX Fragment (<>) was incorrectly closed with a </div>.

Changed the closing tag to </> to match the opening fragment, correcting the syntax.