### PR TITLE
feat: Apply global gradient background

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,6 +5,7 @@
 body {
   margin: 0;
   /* font-family: Arial, sans-serif; */ /* Tailwind's base will handle this */
+  background: linear-gradient(to right, #60a5fa, #2563eb);
 }
 
 #sidebar.active-sidebar {


### PR DESCRIPTION
This commit introduces a global gradient background to the application. The gradient is applied to the `body` element in `src/styles/globals.css`, ensuring it appears on all pages.

The gradient transitions from a light blue (#60a5fa) to a darker blue (#2563eb), similar to Tailwind's blue-400 to blue-600.