### PR TITLE
fix: Update global gradient background colors

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,7 +5,7 @@
 body {
   margin: 0;
   /* font-family: Arial, sans-serif; */ /* Tailwind's base will handle this */
-  background: linear-gradient(to right, #60a5fa, #2563eb);
+  background: linear-gradient(to right, #edf3fd, #f7f8fc);
 }
 
 #sidebar.active-sidebar {


### PR DESCRIPTION
This commit updates the global gradient background colors based on your feedback. The gradient applied to the `body` element in `src/styles/globals.css` now transitions from #edf3fd (left) to #f7f8fc (right).