### PR TITLE
refactor: Move property admin buttons to details page and adjust card…

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -224,7 +224,7 @@ const PropertiesPage = () => {
             {properties.map(property => (
               <Link href={`/property-details/${property.id}`} key={property.id} passHref>
                 <article className="group cursor-pointer">
-                  <div data-slot="card" className="text-card-foreground flex flex-col gap-6 rounded-xl py-6 overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-1 bg-white/80 backdrop-blur-sm">
+                  <div data-slot="card" className="text-card-foreground flex flex-col gap-6 rounded-xl overflow-hidden border-0 shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-1 bg-white/80 backdrop-blur-sm">
                     <div className="relative">
                       <figure className="aspect-[4/3] overflow-hidden m-0 p-0">
                         <img
@@ -301,16 +301,6 @@ const PropertiesPage = () => {
                           </button>
                         )}
                       </div>
-                      {isAdmin && (
-                        <div className="mt-4 pt-4 border-t border-slate-200 flex justify-end gap-2">
-                          <button onClick={(e) => {
-                            e.preventDefault(); e.stopPropagation(); handleOpenEditModal(property);
-                          }} className="px-3 py-1.5 text-xs font-medium text-slate-700 bg-slate-100 rounded-md hover:bg-slate-200 transition-colors">Edit</button>
-                          <button onClick={(e) => {
-                            e.preventDefault(); e.stopPropagation(); handleDeleteProperty(property.id);
-                          }} className="px-3 py-1.5 text-xs font-medium text-white bg-red-500 rounded-md hover:bg-red-600 transition-colors">Delete</button>
-                        </div>
-                      )}
                     </div>
                   </div>
                 </article>


### PR DESCRIPTION
… padding

This commit refactors the placement of property administration buttons (Edit, Delete) and adjusts styling on the property cards.

Key changes:

1.  **Removed Admin Buttons from Property Cards (`properties.js`):**
    - The 'Edit' and 'Delete' buttons have been removed from the individual property cards displayed on the main properties listing page. This declutters the card view.

2.  **Removed `py-6` from Property Cards (`properties.js`):**
    - The `py-6` (vertical padding) Tailwind CSS class was removed from the main `div[data-slot="card"]` element on the property cards to refine their spacing.

3.  **Added Admin Buttons to Property Details Page (`property-details/[id].js`):**
    - 'Edit Property' and 'Delete Property' buttons are now located on the property details page.
    - These buttons are styled using Tailwind CSS and are conditionally rendered, appearing only if the logged-in user has admin privileges (`isAdmin`).
    - The header section of the details page, including the property title and the button container, has been updated to use Tailwind CSS for layout and styling.

4.  **Implemented Button Logic on Details Page:**
    - **Edit Button:** - Imports `AddEditPropertyModal`. - Manages state for modal visibility. - On click, opens the `AddEditPropertyModal` pre-filled with the current property's data. - After saving changes in the modal, the property details on the page are refreshed.
    - **Delete Button:**
        - Prompts you for confirmation before proceeding with deletion.
        - Calls the Supabase client to delete the property record. - On successful deletion, you are navigated back to the main `/properties` listing page. - Includes error handling for the deletion process.
    - Data fetching logic on the details page was refactored to support data refresh after edits.