### PR TITLE
feat: Replace description with static choice chips on properties page

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -210,7 +210,18 @@ const PropertiesPage = () => {
       <section className="px-6 pb-12">
         <div className="mb-8">
           <h2 className="text-3xl font-bold text-slate-900 mb-2" data-i18n="propertiesPage.title">Properties</h2>
-          <p className="text-slate-600 max-w-2xl" data-i18n="propertiesPage.description">Manage and monitor all your properties from one central dashboard. Track maintenance tasks, view property details, and stay organized.</p>
+          <div className="flex flex-wrap gap-3 mt-4 mb-4">
+            {['Customer 1', 'Customer 2', 'Customer 3', 'Customer 4', 'Customer 5'].map(customerName => (
+              <div
+                key={customerName}
+                className="px-4 py-1.5 text-sm font-medium text-blue-700 bg-blue-100 rounded-full border border-blue-200 cursor-pointer hover:bg-blue-200 hover:border-blue-300 transition-all duration-200 shadow-sm hover:shadow-md transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                role="button" // Added role for accessibility
+                tabIndex={0}  // Added tabIndex for keyboard focus
+              >
+                {customerName}
+              </div>
+            ))}
+          </div>
         </div>
 
         {error && <div className="alert alert-danger">Error: {error}</div>}


### PR DESCRIPTION
This commit replaces the descriptive paragraph below the "Properties" title on the properties page with a set of five static choice chips.

Key changes in `src/pages/properties.js`:
- Removed the `<p class="text-slate-600 max-w-2xl" ...>` element.
- Added a new `div` container styled with Tailwind CSS (`flex flex-wrap gap-3 mt-4 mb-4`).
- Inside the container, five static choice chips (e.g., "Customer 1", "Customer 2", etc.) are rendered.
- Each chip is styled using Tailwind CSS to provide a modern appearance with:
    - A blue color theme (`text-blue-700 bg-blue-100 border-blue-200`).
    - Rounded full shape (`rounded-full`).
    - Appropriate padding and text styling (`px-4 py-1.5 text-sm font-medium`).
    - Interactive cues such as `cursor-pointer` and hover/focus effects (background/border color changes, shadow, scale transform).
    - Transitions for smooth visual feedback (`transition-all duration-200`).
    - Basic accessibility attributes (`role="button"`, `tabIndex={0}`).

This change updates the UI as per your request for static choice chips.