### PR TITLE
fix: Remove H2 heading from properties page and adjust spacing

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -208,8 +208,7 @@ const PropertiesPage = () => {
       </header>
 
       <section className="px-6 pb-12">
-        <div className="mb-8">
-          <h2 className="text-3xl font-bold text-slate-900 mb-2" data-i18n="propertiesPage.title">Properties</h2>
+        <div className="">
           <div className="flex flex-wrap gap-3 mt-4 mb-4">
             {['All', 'Customer 1', 'Customer 2', 'Customer 3', 'Customer 4', 'Customer 5'].map(customerName => {
               const isActive = customerName === 'All';


### PR DESCRIPTION
This commit removes the `<h2>Properties</h2>` heading from the main properties listing page (`src/pages/properties.js`).

Additionally, the `mb-8` (margin-bottom) class was removed from the `div` element that previously contained this heading and the page description (which is now a set of choice chips). The choice chips container retains its `mt-4` (margin-top), ensuring appropriate spacing from the main page header section located above it.