### PR TITLE
fix: Apply single-line text truncation to property card name and address

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -286,10 +286,10 @@ const PropertiesPage = () => {
                     </div>
                     <div data-slot="card-content" className="p-6"> {/* Corrected padding to p-6 */}
                       <header className="mb-4">
-                        <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-blue-700 transition-colors">
+                        <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-blue-700 transition-colors truncate">
                           {property.property_name || 'N/A'}
                         </h3>
-                        <address className="text-slate-600 not-italic text-sm leading-relaxed">
+                        <address className="text-slate-600 not-italic text-sm leading-relaxed truncate">
                           {property.address || 'N/A'}
                         </address>
                       </header>


### PR DESCRIPTION
This commit updates the property cards on the properties page (`src/pages/properties.js`) to ensure that long property names and addresses are truncated with an ellipsis (...) if they exceed the available width on a single line.

The `truncate` Tailwind CSS utility class has been added to:
- The `<h3>` element displaying the property name.
- The `<address>` element displaying the property address.

This prevents text overflow and maintains a consistent layout for the cards by enforcing a single-line display for these fields.