### PR TITLE
fix: Increase search input left padding to prevent icon overlap

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -156,7 +156,7 @@ const PropertiesPage = () => {
                 </svg>
                 <input
                   type="text"
-                  className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border border-slate-200 px-3 py-1 text-base md:text-sm shadow-xs outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 pl-8 bg-white/60 focus:bg-white transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+                  className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border border-slate-200 px-3 py-1 text-base md:text-sm shadow-xs outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 pl-9 bg-white/60 focus:bg-white transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
                   placeholder="Search properties..."
                   value={searchQuery}
                   onChange={handleSearchChange}


### PR DESCRIPTION
This commit further adjusts the styling of the search input field on the properties page (`src/pages/properties.js`) to resolve an issue where the placeholder text was visually overlapping with the search icon.

The Tailwind CSS class for left padding has been changed from `pl-8` (2rem) to `pl-9` (2.25rem). This increases the clearance between the absolutely positioned search icon and the start of the text within the input field to `0.5rem`, ensuring no visual overlap.