### PR TITLE
fix: Force search input left padding with inline style

### DIFF
--- a/src/pages/properties.js
+++ b/src/pages/properties.js
@@ -156,10 +156,11 @@ const PropertiesPage = () => {
                 </svg>
                 <input
                   type="text"
-                  className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border border-slate-200 px-3 py-1 text-base md:text-sm shadow-xs outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 pl-10 bg-white/60 focus:bg-white transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+                  className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border border-slate-200 px-3 py-1 text-base md:text-sm shadow-xs outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 pl-8 bg-white/60 focus:bg-white transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
                   placeholder="Search properties..."
                   value={searchQuery}
                   onChange={handleSearchChange}
+                  style={{ paddingLeft: '2rem !important' }}
                 />
               </div>
               <div className="flex gap-2">


### PR DESCRIPTION
This commit applies an inline style with `!important` to the search input field on the properties page (`src/pages/properties.js`) to definitively set its left padding to `2rem`.

This is in response to a persistent issue where the placeholder text was visually overlapping with the search icon, despite previous attempts to adjust padding using Tailwind utility classes.

Changes:
- The `className` for the search input now includes `pl-8` (2rem) as a fallback.
- An inline style `style={{ paddingLeft: '2rem !important' }}` has been added to the input element to ensure the 2rem left padding is applied and overrides any conflicting styles.