### PR TITLE
feat: Implement collapsible sidebar functionality

### DIFF
--- a/src/components/layout/MainLayout.js
+++ b/src/components/layout/MainLayout.js
@@ -8,6 +8,11 @@ import { useRouter } from 'next/router';
 const MainLayout = ({ children }) => {
   const router = useRouter();
   const [showAccessDeniedModal, setShowAccessDeniedModal] = useState(false);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+  const toggleSidebar = () => {
+    setIsSidebarCollapsed(!isSidebarCollapsed);
+  };
 
   const handleShowAccessDenied = () => setShowAccessDeniedModal(true);
   const handleCloseAccessDenied = () => setShowAccessDeniedModal(false);
@@ -33,9 +38,13 @@ const MainLayout = ({ children }) => {
   return (
     <>
       {/* Sidebar is positioned fixed, so it's not part of this flex container directly affecting layout flow of main-content-area on mobile */}
-      <Sidebar />
+      <Sidebar isSidebarCollapsed={isSidebarCollapsed} toggleSidebar={toggleSidebar} />
       {/* On md screens and up, main-content-area will have ml applied to account for the sidebar that is always visible */}
-      <div className="flex flex-col flex-1 md:ml-[calc(16rem+1.5rem)]"> {/* main-content-area equivalent */}
+      <div
+        className={`flex flex-col flex-1 transition-all duration-300 ease-in-out ${
+          isSidebarCollapsed ? 'md:ml-[calc(5rem+1.5rem)]' : 'md:ml-[calc(16rem+1.5rem)]'
+        }`}
+      > {/* main-content-area equivalent */}
         <TopBar /> {/* TopBar might need to span full width or be contained within this column */}
         <main className="p-3 page-content flex-1"> {/* Padding for content area, flex-1 to take available space */}
           {children}

--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -58,7 +58,7 @@ const CustomToggle = forwardRef(({ children, onClick }, ref) => (
 ));
 CustomToggle.displayName = 'CustomToggle';
 
-const Sidebar = () => {
+const Sidebar = ({ isSidebarCollapsed, toggleSidebar }) => {
   const router = useRouter();
   const { isAdmin, loading: authLoading, user, signOut } = useAuth(); // Added signOut
 
@@ -101,13 +101,21 @@ const Sidebar = () => {
   };
 
   return (
-    <aside id="sidebar" className="fixed left-6 top-6 bottom-6 z-50 transition-transform duration-300 ease-in-out w-64 -translate-x-full sm:translate-x-0 border border-white/20 rounded-2xl shadow-xl shadow-black/5 bg-white/80 backdrop-blur-xl">
-      <nav className="h-full p-6 flex flex-col" aria-label="Main navigation">
-        <div className="flex items-center gap-3 mb-8">
-          <div className="w-8 h-8 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-lg flex items-center justify-center">
+    <aside
+      id="sidebar"
+      className={`fixed left-6 top-6 bottom-6 z-50 transition-all duration-300 ease-in-out ${isSidebarCollapsed ? 'w-20' : 'w-64'} -translate-x-full sm:translate-x-0 border border-white/20 rounded-2xl shadow-xl shadow-black/5 bg-white/80 backdrop-blur-xl`}
+    >
+      <nav
+        className={`h-full flex flex-col transition-all duration-300 ease-in-out ${isSidebarCollapsed ? 'p-3' : 'p-6'}`}
+        aria-label="Main navigation"
+      >
+        <div className={`flex items-center mb-8 ${isSidebarCollapsed ? 'justify-center' : 'gap-3'}`}>
+          <div className="w-8 h-8 bg-gradient-to-br from-blue-600 to-indigo-600 rounded-lg flex items-center justify-center flex-shrink-0">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-house w-4 h-4 text-white"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"></path><path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path></svg>
           </div>
-          <h1 className="text-xl font-bold text-slate-900">PropertyHub</h1>
+          {!isSidebarCollapsed && (
+            <h1 className="text-xl font-bold text-slate-900">PropertyHub</h1>
+          )}
         </div>
 
         <ul className="space-y-2 flex-1">
@@ -121,12 +129,16 @@ const Sidebar = () => {
 
             const active = isActive(link.path);
 
-            const baseLinkClasses = "flex items-center gap-3 px-3 py-3 rounded-xl transition-all duration-200 group relative";
+            const baseLinkClasses = `flex items-center py-3 rounded-xl transition-all duration-200 group relative ${
+              isSidebarCollapsed
+                ? 'px-3 justify-center'
+                : 'px-3 gap-3'
+            }`;
             const activeStateSpecificClasses = "bg-blue-50 text-blue-700 font-semibold shadow-sm";
             const inactiveStateSpecificClasses = "text-slate-600 hover:bg-slate-50 hover:text-slate-900";
             const linkClassName = `${baseLinkClasses} ${active ? activeStateSpecificClasses : inactiveStateSpecificClasses}`;
 
-            const baseIconClasses = "w-5 h-5 transition-colors"; // Size is defined here
+            const baseIconClasses = "w-5 h-5 transition-colors flex-shrink-0"; // Added flex-shrink-0
             const activeIconStateClasses = "text-blue-600";
             const inactiveIconStateClasses = "text-slate-500 group-hover:text-slate-700";
             const iconClassName = `${baseIconClasses} ${active ? activeIconStateClasses : inactiveIconStateClasses}`;
@@ -138,7 +150,9 @@ const Sidebar = () => {
                     <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-blue-600 rounded-r-full"></div>
                   )}
                   {getIconForPath(link.path, iconClassName)}
-                  <span className="font-medium">{link.label}</span>
+                  {!isSidebarCollapsed && (
+                    <span className="font-medium">{link.label}</span>
+                  )}
                 </Link>
               </li>
             );
@@ -146,21 +160,23 @@ const Sidebar = () => {
         </ul>
 
         <div className="px-3 py-4 border-t border-slate-200">
-          <div className="flex items-center gap-3 group">
-            <span className="relative flex size-8 shrink-0 overflow-hidden rounded-full h-10 w-10 ring-2 ring-slate-100 transition-all duration-200 group-hover:ring-blue-200">
+          <div className={`flex items-center group ${isSidebarCollapsed ? 'gap-0 justify-center' : 'gap-3'}`}>
+            <span className="relative flex size-8 shrink-0 overflow-hidden rounded-full h-10 w-10 ring-2 ring-slate-100 transition-all duration-200 group-hover:ring-blue-200 flex-shrink-0">
               <img className="aspect-square size-full object-cover" alt={`${profileUser.name || 'User'}'s profile picture`} src={profileUser.avatarUrl || '/assets/images/placeholder-avatar.png'} />
             </span>
-            <div className="flex-1 min-w-0">
+            <div className={`flex-1 min-w-0 ${isSidebarCollapsed ? 'w-0 overflow-hidden opacity-0' : 'opacity-100'} transition-all duration-300`}>
               <h3 className="font-semibold text-slate-900 text-sm truncate leading-tight">{profileUser.name || (user ? (user.user_metadata?.first_name || 'User') : 'Guest')}</h3>
               <p className="text-xs text-slate-500 truncate leading-relaxed mt-0.5">{user ? user.email : 'Not logged in'}</p>
             </div>
-            <Dropdown align="end" drop="up">
-              <Dropdown.Toggle as={CustomToggle} id="sidebar-user-options">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-ellipsis-vertical h-4 w-4">
-                  <circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle>
-                </svg>
-              </Dropdown.Toggle>
-              <Dropdown.Menu className="shadow-lg mb-2">
+            {/* Conditionally hide dropdown toggle if sidebar is collapsed and there's no text? Or just let it be small? For now, keep it. Add flex-shrink-0 to prevent it from being squeezed out if space is extremely tight. */}
+            <div className={`${isSidebarCollapsed ? 'w-0 overflow-hidden opacity-0' : 'opacity-100'} transition-opacity duration-300 flex-shrink-0`}>
+              <Dropdown align="end" drop="up">
+                <Dropdown.Toggle as={CustomToggle} id="sidebar-user-options">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-ellipsis-vertical h-4 w-4">
+                    <circle cx="12" cy="12" r="1"></circle><circle cx="12" cy="5" r="1"></circle><circle cx="12" cy="19" r="1"></circle>
+                  </svg>
+                </Dropdown.Toggle>
+                <Dropdown.Menu className="shadow-lg mb-2">
                 <Dropdown.Item as={Link} href="/account" legacyBehavior={false}>
                   <a className="dropdown-item flex items-center gap-2">
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-settings w-4 h-4"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.1a2 2 0 0 1-1-1.72v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>
@@ -176,11 +192,40 @@ const Sidebar = () => {
             </Dropdown>
           </div>
         </div>
-        <div className="pt-3 border-t border-slate-200">
-          <button className="inline-flex items-center whitespace-nowrap text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg:not([class*='size-'])]:size-4 shrink-0 [&amp;_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:bg-accent dark:hover:bg-accent/50 h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5 w-full justify-start text-slate-600 hover:text-slate-900">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-circle-help w-4 h-4 mr-2"><circle cx="12" cy="12" r="10"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><path d="M12 17h.01"></path></svg>
-            Help & Support
-          </button>
+        <div className={`pt-3 border-t border-slate-200 ${isSidebarCollapsed ? 'mt-auto' : ''}`}>
+          <div className="flex items-center justify-between">
+            <button
+              className={`inline-flex items-center whitespace-nowrap text-sm font-medium transition-all duration-200 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] hover:bg-accent h-8 rounded-md gap-1.5 text-slate-600 hover:text-slate-900 ${
+                isSidebarCollapsed ? 'px-1 justify-center flex-1' : 'px-3 justify-start flex-1'
+              }`}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={`lucide lucide-circle-help w-4 h-4 flex-shrink-0 ${isSidebarCollapsed ? '' : 'mr-2'}`}>
+                <circle cx="12" cy="12" r="10"></circle>
+                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+                <path d="M12 17h.01"></path>
+              </svg>
+              {!isSidebarCollapsed && (
+                <span>Help & Support</span>
+              )}
+            </button>
+
+            <button
+              onClick={toggleSidebar}
+              aria-label={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              className="p-2 rounded-md hover:bg-slate-200 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className={`w-5 h-5 text-slate-600 transition-transform duration-300 ease-in-out ${isSidebarCollapsed ? 'rotate-180' : ''}`}
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                 <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+          </div>
         </div>
       </nav>
     </aside>


### PR DESCRIPTION
This commit introduces a collapsible sidebar feature, allowing you to minimize the sidebar to an icon-only view, providing more space for the main content area.

Key changes:

1.  **State Management (`MainLayout.js`):**
    - Added `isSidebarCollapsed` state (default: false) to `MainLayout.js`.
    - Implemented a `toggleSidebar` function to update this state.
    - Passed `isSidebarCollapsed` and `toggleSidebar` as props to the `Sidebar` component.

2.  **Main Content Adjustment (`MainLayout.js`):**
    - The main content area's left margin (`md:ml-[...]`) is now dynamically adjusted based on `isSidebarCollapsed` to smoothly accommodate the sidebar's width changes.
    - CSS transitions (`transition-all duration-300 ease-in-out`) are applied for smooth animation.

3.  **Sidebar Styling (`Sidebar.js`):**
    - The sidebar's main container (`<aside>`) now dynamically changes its width (`w-64` to `w-20`) and padding (`p-6` to `p-3`) based on `isSidebarCollapsed`.
    - `transition-all` is used for smooth visual transitions of these properties.

4.  **Sidebar Content Adaptation (`Sidebar.js`):**
    - **Header/Logo:** The "PropertyHub" text is hidden when the sidebar is collapsed, showing only the logo icon, which is then centered.
    - **Navigation Links:** Text labels for navigation links are hidden in the collapsed state. Icons are centered and `flex-shrink-0` is applied.
    - **User Profile Section:** Your name and email are hidden with a transition when collapsed, leaving the avatar. The layout adjusts to center remaining elements.
    - **"Help & Support" Link:** Text is hidden, and the icon is centered when collapsed.

5.  **Trigger Button (`Sidebar.js`):**
    - A new trigger button has been added to the bottom-right of the sidebar, aligned with the "Help & Support" link.
    - The button calls `toggleSidebar` on click.
    - It features an SVG chevron icon that rotates 180 degrees (`transition-transform`) to indicate the current state (expanded/collapsed) and the action to be performed.
    - The button includes an `aria-label` for accessibility.
    - The container for the "Help & Support" and trigger button is pushed to the bottom (`mt-auto`) when the sidebar is collapsed and the navigation list shrinks.