### PR TITLE
fix: Correct modal padding in CreateEditTaskModal

### DIFF
--- a/src/components/modals/CreateEditTaskModal.jsx
+++ b/src/components/modals/CreateEditTaskModal.jsx
@@ -231,7 +231,7 @@ const CreateEditTaskModal = ({ isOpen, onClose, task, onSave, propertiesList, st
         onClick={(e) => e.stopPropagation()} // Prevent clicks inside modal from closing it
       >
         {/* Modal Header */}
-        <div className="flex justify-between items-center p-5 border-b border-slate-200">
+        <div className="flex justify-between items-center p-3 border-b border-slate-200">
           <h3 id="modal-title" className="text-xl font-semibold text-slate-800">
             {task && task.task_id ? 'Edit Task' : 'Create New Task'}
           </h3>
@@ -379,7 +379,7 @@ const CreateEditTaskModal = ({ isOpen, onClose, task, onSave, propertiesList, st
         </div>
 
         {/* Modal Footer */}
-        <div className="flex justify-end items-center gap-3 p-5 bg-slate-50 rounded-b-2xl border-t border-slate-200">
+        <div className="flex justify-end items-center gap-3 p-3 bg-slate-50 rounded-b-2xl border-t border-slate-200">
           <button
             type="button"
             onClick={handleClose}


### PR DESCRIPTION
This commit addresses an issue where the header and footer of the CreateEditTaskModal component had excessive padding, potentially due to a global CSS rule for `p-5` with `!important`.

- Changed the Tailwind CSS padding class for the modal header in `src/components/modals/CreateEditTaskModal.jsx` from `p-5` to `p-3`.
- Changed the Tailwind CSS padding class for the modal footer in `src/components/modals/CreateEditTaskModal.jsx` from `p-5` to `p-3`.

These changes ensure that the modal header and footer use a smaller, more appropriate padding (0.75rem / 12px), overriding any problematic global styles associated with `p-5` for these specific elements. This results in a more compact and visually balanced modal.