### PR TITLE
I've corrected the import path for the TaskActionsDropdown component …

### DIFF
--- a/src/pages/tasks.js
+++ b/src/pages/tasks.js
@@ -3,7 +3,7 @@ import { supabase } from '@/lib/supabaseClient';
 import { useAuth } from '../context/AuthContext';
 import CreateEditTaskModal from '../components/modals/CreateEditTaskModal';
 import ViewTaskModal from '../components/modals/ViewTaskModal';
-import TaskActionsDropdown from '../../components/utils/TaskActionsDropdown'; // Import the new dropdown
+import TaskActionsDropdown from '../components/utils/TaskActionsDropdown'; // Import path corrected
 
 const ITEMS_PER_PAGE = 10;
 


### PR DESCRIPTION
…in `src/pages/tasks.js` to resolve a "Module not found" error during Vercel deployment.

The path was changed from `../../components/utils/TaskActionsDropdown` to `../components/utils/TaskActionsDropdown`.