### PR TITLE
fix: Remove tasks table scroll & align ViewTaskModal style

### DIFF
--- a/src/components/modals/ViewTaskModal.jsx
+++ b/src/components/modals/ViewTaskModal.jsx
@@ -207,14 +207,14 @@ const ViewTaskModal = ({ isOpen, onClose, task, onAttachmentDeleted, onTaskUpdat
         onClick={(e) => e.stopPropagation()}
       >
         {/* Modal Header */}
-        <div className="flex justify-between items-center p-5 border-b border-slate-200">
+        <div className="flex justify-between items-center p-3 border-b border-slate-200">
           <h3 id="view-task-modal-title" className="text-xl font-semibold text-slate-800">
             Task Details
           </h3>
           <button
             type="button"
             onClick={onClose}
-            className="p-1.5 text-slate-400 hover:text-slate-700 hover:bg-slate-100 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400"
+            className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-slate-300"
             aria-label="Close modal"
           >
             <IconX className="w-5 h-5" />
@@ -308,7 +308,7 @@ const ViewTaskModal = ({ isOpen, onClose, task, onAttachmentDeleted, onTaskUpdat
         </div>
 
         {/* Modal Footer */}
-        <div className="flex justify-end items-center gap-3 p-5 bg-slate-50/70 border-t border-slate-200 rounded-b-2xl">
+        <div className="flex justify-end items-center gap-3 p-3 bg-slate-50 rounded-b-2xl border-t border-slate-200">
           <button
             type="button"
             onClick={onClose}

--- a/src/pages/tasks.js
+++ b/src/pages/tasks.js
@@ -245,7 +245,7 @@ const TasksPage = () => {
             <p className="mt-1 text-sm text-slate-500">No tasks match your current filters or search query.</p>
           </div>
         ) : (
-          <div className="overflow-x-auto bg-white/80 backdrop-blur-sm rounded-xl shadow-lg border-0">
+          <div className="bg-white/80 backdrop-blur-sm rounded-xl shadow-lg border-0">
             <table className="min-w-full text-sm text-left">
               <thead className="text-xs text-slate-700 uppercase bg-slate-50/70">
                 <tr>


### PR DESCRIPTION
This commit includes two main changes:

1.  **Tasks Page Table Scroll Removal:**
    - Removed the `overflow-x-auto` class from the container wrapping the tasks table in `src/pages/tasks.js`. This disables the horizontal scrollbar for the table, allowing default browser handling for wide table content.

2.  **ViewTaskModal Styling Update:**
    - Restyled the header and footer of `src/components/modals/ViewTaskModal.jsx` to match the appearance of `CreateEditTaskModal.jsx`.
    - Header padding changed from `p-5` to `p-3`.
    - Close button styling in the header updated for consistency.
    - Footer padding changed from `p-5` to `p-3`.
    - Footer background color changed from `bg-slate-50/70` to `bg-slate-50` (solid).

These changes address your feedback to remove the horizontal scroll on the tasks table and to ensure visual consistency between the View Task and Create/Edit Task modals.