### PR TITLE
feat: Add text animations and ensure chevron alignment in sidebar

### DIFF
--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -150,9 +150,15 @@ const Sidebar = ({ isSidebarCollapsed, toggleSidebar }) => {
                     <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-blue-600 rounded-r-full"></div>
                   )}
                   {getIconForPath(link.path, iconClassName)}
-                  {!isSidebarCollapsed && (
-                    <span className="font-medium">{link.label}</span>
-                  )}
+                  <span
+                    className={`font-medium whitespace-nowrap overflow-hidden transition-all duration-300 ease-in-out ${
+                      isSidebarCollapsed
+                        ? 'opacity-0 -translate-x-4 pointer-events-none w-0'
+                        : 'opacity-100 translate-x-0 w-auto'
+                    }`}
+                  >
+                    {link.label}
+                  </span>
                 </Link>
               </li>
             );


### PR DESCRIPTION
This commit introduces animations for navigation item text in the sidebar and verifies the vertical alignment of the collapse/expand chevron icon.

1.  **Navigation Item Text Animation (`src/components/layout/Sidebar.js`):**
    *   I modified the `<span>` elements for navigation link labels to be always present in the DOM, rather than conditionally rendered.
    *   I applied conditional Tailwind CSS classes to these spans based on the `isSidebarCollapsed` state:
        *   When collapsing: Text now fades out (opacity to 0), slides to the left (`-translate-x-4`), and its width collapses (`w-0`).
        *   When expanding: Text fades in (opacity to 100), slides back to its original position (`translate-x-0`), and its width expands (`w-auto`).
    *   Base classes `transition-all duration-300 ease-in-out`, `whitespace-nowrap`, and `overflow-hidden` are used to ensure smooth animation and proper text handling.

2.  **Chevron Vertical Alignment in Collapsed State (`src/components/layout/Sidebar.js`):**
    *   I reviewed the existing structure for the chevron toggle button's container at the bottom of the sidebar.
    *   I confirmed that the existing `items-center` Tailwind CSS class on the flex container correctly ensures the chevron icon is vertically centered within its line when the sidebar is collapsed. No code changes were necessary for this specific requirement as the current implementation already supports it.

These changes enhance the visual feedback when interacting with the sidebar and ensure the toggle control is properly aligned.